### PR TITLE
Use Go modules and fix compilation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wf-migrate
 
-[![GoDoc](https://godoc.org/github.com/writeas/wf-migrate?status.svg)](https://godoc.org/github.com/writeas/wf-migrate)
+[![GoDoc](https://pkg.go.dev/badge/github.com/writefreely/wf-migrate?status.svg)](https://pkg.go.dev/github.com/writefreely/wf-migrate)
 
 wf-migrate provides helper functions and a command-line utility for migrating posts between [WriteFreely](https://writefreely.org) instances.
 
@@ -9,7 +9,7 @@ wf-migrate provides helper functions and a command-line utility for migrating po
 Install the command-line utility with:
 
 ```
-go get github.com/writeas/wf-migrate/cmd/wfimport
+go install github.com/writefreely/wf-migrate/cmd/wfimport
 ```
 
 `wfimport` takes a username `-u`, optional WriteFreely instance hostname `-h`, and the filename of the JSON data you want to import.

--- a/cmd/wfimport/main.go
+++ b/cmd/wfimport/main.go
@@ -5,8 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"github.com/howeyc/gopass"
-	"github.com/writeas/go-writeas"
-	"github.com/writeas/wf-migrate"
+	"github.com/writeas/go-writeas/v2"
+	"github.com/writefreely/wf-migrate"
 	"io/ioutil"
 	"os"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,16 @@
+module github.com/writefreely/wf-migrate
+
+go 1.23.0
+
+require (
+	github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef
+	github.com/writeas/go-writeas/v2 v2.1.0
+)
+
+require (
+	code.as/core/socks v1.0.0 // indirect
+	github.com/writeas/impart v1.1.1 // indirect
+	golang.org/x/crypto v0.28.0 // indirect
+	golang.org/x/sys v0.26.0 // indirect
+	golang.org/x/term v0.25.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+code.as/core/socks v1.0.0 h1:SPQXNp4SbEwjOAP9VzUahLHak8SDqy5n+9cm9tpjZOs=
+code.as/core/socks v1.0.0/go.mod h1:BAXBy5O9s2gmw6UxLqNJcVbWY7C/UPs+801CcSsfWOY=
+github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef h1:A9HsByNhogrvm9cWb28sjiS3i7tcKCkflWFEkHfuAgM=
+github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
+github.com/writeas/go-writeas/v2 v2.1.0 h1:Wot4JX63ygKe/V30jwNYCBUgqjN4Tz0vrk9+Ujya1p4=
+github.com/writeas/go-writeas/v2 v2.1.0/go.mod h1:9sjczQJKmru925fLzg0usrU1R1tE4vBmQtGnItUMR0M=
+github.com/writeas/impart v1.1.0/go.mod h1:g0MpxdnTOHHrl+Ca/2oMXUHJ0PcRAEWtkCzYCJUXC9Y=
+github.com/writeas/impart v1.1.1 h1:RyA9+CqbdbDuz53k+nXCWUY+NlEkdyw6+nWanxSBl5o=
+github.com/writeas/impart v1.1.1/go.mod h1:g0MpxdnTOHHrl+Ca/2oMXUHJ0PcRAEWtkCzYCJUXC9Y=
+golang.org/x/crypto v0.28.0 h1:GBDwsMXVQi34v5CCYUm2jkJvu4cbtru2U4TN2PSyQnw=
+golang.org/x/crypto v0.28.0/go.mod h1:rmgy+3RHxRZMyY0jjAJShp2zgEdOqj2AO7U0pYmeQ7U=
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.25.0 h1:WtHI/ltw4NvSUig5KARz9h521QvRC8RmF/cuYqifU24=
+golang.org/x/term v0.25.0/go.mod h1:RPyXicDX+6vLxogjjRxjgD2TKtmAO6NZBsBRfrOLu7M=

--- a/import.go
+++ b/import.go
@@ -1,6 +1,6 @@
 package wfmigrate
 
-import "github.com/writeas/go-writeas"
+import "github.com/writeas/go-writeas/v2"
 
 type Import struct {
 	writeas.User


### PR DESCRIPTION
This moves the repo from github.com/writeas/wf-migrate to github.com/writefreely/wf-migrate, adds support for Go modules, and uses the latest github.com/writeas/go-writeas library to fix the compilation errors mentioned in #1.